### PR TITLE
[DNM] refactored code test to not break anything

### DIFF
--- a/spec/vcr_cassettes/manager_refresh/inventory_collection_default-refactoring.yml
+++ b/spec/vcr_cassettes/manager_refresh/inventory_collection_default-refactoring.yml
@@ -1,0 +1,258 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/ManageIQ/manageiq/8696169931b6b6c184ac21022162e99b3e21d236/app/models/manager_refresh/inventory_collection_default.rb
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"02585fc98d11454dd5dd7cf0b130b1a8149170fc"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 519A:40B0:56408A:591841:5A8714BC
+      Content-Length:
+      - '1176'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 16 Feb 2018 17:28:31 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-ams4128-AMS
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1518802111.872414,VS0,VE147
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - f4108b3c8ac2232b8431b9423b420ad8946429ee
+      Expires:
+      - Fri, 16 Feb 2018 17:33:31 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        class ManagerRefresh::InventoryCollectionDefault
+          class << self
+            def vms(extra_attributes = {})
+              attributes = {
+                :model_class                 => ::Vm,
+                :association                 => :vms,
+                :delete_method               => :disconnect_inv,
+                :attributes_blacklist        => [:genealogy_parent],
+                :use_ar_object               => true, # Because of raw_power_state setter and hooks are needed for settings user
+                # TODO(lsmola) can't do batch strategy for vms because of key_pairs relation
+                :saver_strategy              => :default,
+                :batch_extra_attributes      => [:power_state, :state_changed_on, :previous_state],
+                :inventory_object_attributes => [
+                  :type,
+                  :cpu_limit,
+                  :cpu_reserve,
+                  :cpu_reserve_expand,
+                  :cpu_shares,
+                  :cpu_shares_level,
+                  :ems_ref,
+                  :ems_ref_obj,
+                  :uid_ems,
+                  :connection_state,
+                  :vendor,
+                  :name,
+                  :location,
+                  :template,
+                  :memory_limit,
+                  :memory_reserve,
+                  :memory_reserve_expand,
+                  :memory_shares,
+                  :memory_shares_level,
+                  :raw_power_state,
+                  :boot_time,
+                  :host,
+                  :ems_cluster,
+                  :storages,
+                  :storage,
+                  :snapshots
+                ],
+                :builder_params              => {
+                  :ems_id   => ->(persister) { persister.manager.id },
+                  :name     => "unknown",
+                  :location => "unknown",
+                }
+              }
+
+              attributes.merge!(extra_attributes)
+            end
+
+            def miq_templates(extra_attributes = {})
+              attributes = {
+                :model_class                 => ::MiqTemplate,
+                :association                 => :miq_templates,
+                :delete_method               => :disconnect_inv,
+                :attributes_blacklist        => [:genealogy_parent],
+                :use_ar_object               => true, # Because of raw_power_state setter
+                :saver_strategy              => :default, # Hooks are needed for setting user
+                :batch_extra_attributes      => [:power_state, :state_changed_on, :previous_state],
+                :inventory_object_attributes => [
+                  :type,
+                  :ems_ref,
+                  :ems_ref_obj,
+                  :uid_ems,
+                  :connection_state,
+                  :vendor,
+                  :name,
+                  :location,
+                  :template,
+                  :memory_limit,
+                  :memory_reserve,
+                  :raw_power_state,
+                  :boot_time,
+                  :host,
+                  :ems_cluster,
+                  :storages,
+                  :storage,
+                  :snapshots
+                ],
+                :builder_params              => {
+                  :ems_id   => ->(persister) { persister.manager.id },
+                  :name     => "unknown",
+                  :location => "unknown",
+                  :template => true
+                }
+              }
+
+              attributes.merge!(extra_attributes)
+            end
+
+            def hardwares(extra_attributes = {})
+              attributes = {
+                :model_class                  => ::Hardware,
+                :manager_ref                  => [:vm_or_template],
+                :association                  => :hardwares,
+                :parent_inventory_collections => [:vms, :miq_templates],
+                :inventory_object_attributes  => [
+                  :annotation,
+                  :cpu_cores_per_socket,
+                  :cpu_sockets,
+                  :cpu_speed,
+                  :cpu_total_cores,
+                  :cpu_type,
+                  :guest_os,
+                  :manufacturer,
+                  :memory_mb,
+                  :model,
+                  :networks,
+                  :number_of_nics,
+                  :serial_number,
+                  :virtual_hw_version
+                ],
+                # TODO(lsmola) just because of default value on cpu_sockets, this can be fixed by separating instances_hardwares and images_hardwares
+                :use_ar_object                => true,
+              }
+
+              attributes[:targeted_arel] = lambda do |inventory_collection|
+                manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
+                inventory_collection.parent.hardwares.joins(:vm_or_template).where(
+                  'vms' => {:ems_ref => manager_uuids}
+                )
+              end
+
+              attributes.merge!(extra_attributes)
+            end
+
+            def operating_systems(extra_attributes = {})
+              attributes = {
+                :model_class                  => ::OperatingSystem,
+                :manager_ref                  => [:vm_or_template],
+                :association                  => :operating_systems,
+                :parent_inventory_collections => [:vms, :miq_templates],
+                :inventory_object_attributes  => [
+                  :name,
+                  :product_name,
+                  :product_type,
+                  :system_type,
+                  :version
+                ],
+              }
+
+              attributes[:targeted_arel] = lambda do |inventory_collection|
+                manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
+                inventory_collection.parent.operating_systems.joins(:vm_or_template).where(
+                  'vms' => {:ems_ref => manager_uuids}
+                )
+              end
+
+              attributes.merge!(extra_attributes)
+            end
+
+            def disks(extra_attributes = {})
+              attributes = {
+                :model_class                  => ::Disk,
+                :manager_ref                  => [:hardware, :device_name],
+                :association                  => :disks,
+                :parent_inventory_collections => [:vms],
+                :inventory_object_attributes  => [
+                  :device_name,
+                  :device_type,
+                  :controller_type,
+                  :present,
+                  :filename,
+                  :location,
+                  :size,
+                  :size_on_disk,
+                  :disk_type,
+                  :mode,
+                  :bootable,
+                  :storage
+                ],
+              }
+
+              attributes[:targeted_arel] = lambda do |inventory_collection|
+                manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
+                inventory_collection.parent.disks.joins(:hardware => :vm_or_template).where(
+                  :hardware => {'vms' => {:ems_ref => manager_uuids}}
+                )
+              end
+
+              attributes.merge!(extra_attributes)
+            end
+          end
+        end
+    http_version: 
+  recorded_at: Fri, 16 Feb 2018 17:28:31 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manager_refresh/inventory_collection_default/infra_manager-refactoring.yml
+++ b/spec/vcr_cassettes/manager_refresh/inventory_collection_default/infra_manager-refactoring.yml
@@ -1,0 +1,499 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/AlexanderZagaynov/manageiq/efaa339af78a230eed513d002ce4487ae162a977/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"b1f4d92a26b01ef043ce36cede2abb38f38b3747"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 30CE:27460:92D495:99E508:5A8AE59C
+      Content-Length:
+      - '1776'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Mon, 19 Feb 2018 14:57:34 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-ams4130-AMS
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1519052255.834390,VS0,VE1
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - a4137444ba1998264ec8682f5483f5e71062c4bb
+      Expires:
+      - Mon, 19 Feb 2018 15:02:34 GMT
+      Source-Age:
+      - '66'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh::InventoryCollectionDefault
+          class << self
+            def networks(extra_attributes = {})
+              attributes = {
+                :model_class                 => ::Network,
+                :manager_ref                 => [:hardware, :ipaddress, :ipv6address],
+                :association                 => :networks,
+                :inventory_object_attributes => [
+                  :description,
+                  :hostname,
+                  :ipaddress,
+                  :subnet_mask,
+                  :ipv6address,
+                ],
+              }
+
+              attributes.merge!(extra_attributes)
+            end
+
+            def host_networks(extra_attributes = {})
+              attributes = {
+                :model_class                 => ::Network,
+                :manager_ref                 => [:hardware, :ipaddress],
+                :association                 => :host_networks,
+                :inventory_object_attributes => [
+                  :description,
+                  :hostname,
+                  :ipaddress,
+                  :subnet_mask
+                ],
+              }
+
+              attributes.merge!(extra_attributes)
+            end
+
+            def guest_devices(extra_attributes = {})
+              attributes = {
+                :model_class                 => ::GuestDevice,
+                :manager_ref                 => [:hardware, :uid_ems],
+                :association                 => :guest_devices,
+                :inventory_object_attributes => [
+                  :address,
+                  :controller_type,
+                  :device_name,
+                  :device_type,
+                  :lan,
+                  :location,
+                  :network,
+                  :present,
+                  :switch,
+                  :uid_ems
+                ],
+              }
+
+              attributes.merge!(extra_attributes)
+            end
+
+            def host_hardwares(extra_attributes = {})
+              attributes = {
+                :model_class => ::Hardware,
+                :manager_ref => [:host],
+                :association => :host_hardwares,
+                :inventory_object_attributes => [
+                  :annotation,
+                  :cpu_cores_per_socket,
+                  :cpu_sockets,
+                  :cpu_speed,
+                  :cpu_total_cores,
+                  :cpu_type,
+                  :guest_os,
+                  :manufacturer,
+                  :memory_mb,
+                  :model,
+                  :networks,
+                  :number_of_nics,
+                  :serial_number
+                ],
+              }
+
+              attributes.merge!(extra_attributes)
+            end
+
+            def snapshots(extra_attributes = {})
+              attributes = {
+                :model_class                 => ::Snapshot,
+                :manager_ref                 => [:uid],
+                :association                 => :snapshots,
+                :inventory_object_attributes => [
+                  :uid_ems,
+                  :uid,
+                  :parent_uid,
+                  :name,
+                  :description,
+                  :create_time,
+                  :current,
+                  :vm_or_template
+                ],
+              }
+
+              attributes.merge!(extra_attributes)
+            end
+
+            def operating_systems(extra_attributes = {})
+              attributes = {
+                :model_class                 => ::OperatingSystem,
+                :manager_ref                 => [:vm_or_template],
+                :association                 => :operating_systems,
+                :inventory_object_attributes => [
+                  :name,
+                  :product_name,
+                  :product_type,
+                  :system_type,
+                  :version
+                ],
+              }
+
+              attributes.merge!(extra_attributes)
+            end
+
+            def host_operating_systems(extra_attributes = {})
+              attributes = {
+                :model_class                 => ::OperatingSystem,
+                :manager_ref                 => [:host],
+                :association                 => :host_operating_systems,
+                :inventory_object_attributes => [
+                  :name,
+                  :product_name,
+                  :product_type,
+                  :system_type,
+                  :version
+                ],
+              }
+
+              attributes.merge!(extra_attributes)
+            end
+
+            def custom_attributes(extra_attributes = {})
+              attributes = {
+                :model_class                 => ::CustomAttribute,
+                :manager_ref                 => [:name],
+                :association                 => :custom_attributes,
+                :inventory_object_attributes => [
+                  :section,
+                  :name,
+                  :value,
+                  :source,
+                ],
+              }
+
+              attributes.merge!(extra_attributes)
+            end
+
+            def ems_folders(extra_attributes = {})
+              attributes = {
+                :model_class                 => ::EmsFolder,
+                :association                 => :ems_folders,
+                :manager_ref                 => [:uid_ems],
+                :attributes_blacklist        => [:ems_children],
+                :inventory_object_attributes => [
+                  :ems_ref,
+                  :name,
+                  :type,
+                  :uid_ems,
+                  :hidden
+                ],
+                :builder_params              => {
+                  :ems_id => ->(persister) { persister.manager.id },
+                },
+              }
+
+              attributes.merge!(extra_attributes)
+            end
+
+            def datacenters(extra_attributes = {})
+              attributes = {
+                :model_class                 => ::Datacenter,
+                :association                 => :datacenters,
+                :inventory_object_attributes => [
+                  :name,
+                  :type,
+                  :uid_ems,
+                  :ems_ref,
+                  :ems_ref_obj,
+                  :hidden
+                ],
+                :builder_params              => {
+                  :ems_id => ->(persister) { persister.manager.id },
+                },
+              }
+
+              attributes.merge!(extra_attributes)
+            end
+
+            def resource_pools(extra_attributes = {})
+              attributes = {
+                :model_class                 => ::ResourcePool,
+                :association                 => :resource_pools,
+                :manager_ref                 => [:uid_ems],
+                :attributes_blacklist        => [:ems_children],
+                :inventory_object_attributes => [
+                  :ems_ref,
+                  :name,
+                  :uid_ems,
+                  :is_default,
+                ],
+                :builder_params              => {
+                  :ems_id => ->(persister) { persister.manager.id },
+                },
+              }
+
+              attributes.merge!(extra_attributes)
+            end
+
+            def ems_clusters(extra_attributes = {})
+              attributes = {
+                :model_class                 => ::EmsCluster,
+                :association                 => :ems_clusters,
+                :attributes_blacklist        => [:ems_children, :datacenter_id],
+                :inventory_object_attributes => [
+                  :ems_ref,
+                  :ems_ref_obj,
+                  :uid_ems,
+                  :name,
+                  :datacenter_id,
+                ],
+                :builder_params              => {
+                  :ems_id => ->(persister) { persister.manager.id },
+                },
+              }
+
+              attributes.merge!(extra_attributes)
+            end
+
+            def storages(extra_attributes = {})
+              attributes = {
+                :model_class                 => ::Storage,
+                :manager_ref                 => [:location],
+                :association                 => :storages,
+                :complete                    => false,
+                :arel                        => Storage,
+                :inventory_object_attributes => [
+                  :ems_ref,
+                  :ems_ref_obj,
+                  :name,
+                  :store_type,
+                  :storage_domain_type,
+                  :total_space,
+                  :free_space,
+                  :uncommitted,
+                  :multiplehostaccess,
+                  :location,
+                  :master
+                ],
+              }
+
+              attributes.merge!(extra_attributes)
+            end
+
+            def hosts(extra_attributes = {})
+              attributes = {
+                :model_class                 => ::Host,
+                :association                 => :hosts,
+                :inventory_object_attributes => [
+                  :type,
+                  :ems_ref,
+                  :ems_ref_obj,
+                  :name,
+                  :hostname,
+                  :ipaddress,
+                  :uid_ems,
+                  :vmm_vendor,
+                  :vmm_product,
+                  :vmm_version,
+                  :vmm_buildnumber,
+                  :connection_state,
+                  :power_state,
+                  :ems_cluster,
+                  :ipmi_address,
+                  :maintenance
+                ],
+                :builder_params              => {
+                  :ems_id => ->(persister) { persister.manager.id },
+                },
+                :custom_reconnect_block      => lambda do |inventory_collection, inventory_objects_index, attributes_index|
+                  relation = inventory_collection.model_class.where(:ems_id => nil)
+
+                  return if relation.count <= 0
+
+                  inventory_objects_index.each_slice(100) do |batch|
+                    relation.where(inventory_collection.manager_ref.first => batch.map(&:first)).each do |record|
+                      index = inventory_collection.object_index_with_keys(inventory_collection.manager_ref_to_cols, record)
+
+                      # We need to delete the record from the inventory_objects_index and attributes_index, otherwise it
+                      # would be sent for create.
+                      inventory_object = inventory_objects_index.delete(index)
+                      hash             = attributes_index.delete(index)
+
+                      record.assign_attributes(hash.except(:id, :type))
+                      if !inventory_collection.check_changed? || record.changed?
+                        record.save!
+                        inventory_collection.store_updated_records(record)
+                      end
+
+                      inventory_object.id = record.id
+                    end
+                  end
+                end
+              }
+
+              attributes.merge!(extra_attributes)
+            end
+
+            def vms(extra_attributes = {})
+              attributes = {
+                :custom_reconnect_block => lambda do |inventory_collection, inventory_objects_index, attributes_index|
+                  relation = inventory_collection.model_class.where(:ems_id => nil)
+
+                  return if relation.count <= 0
+
+                  inventory_objects_index.each_slice(100) do |batch|
+                    relation.where(inventory_collection.manager_ref.first => batch.map(&:first)).each do |record|
+                      index = inventory_collection.object_index_with_keys(inventory_collection.manager_ref_to_cols, record)
+
+                      # We need to delete the record from the inventory_objects_index and attributes_index, otherwise it
+                      # would be sent for create.
+                      inventory_object = inventory_objects_index.delete(index)
+                      hash             = attributes_index.delete(index)
+
+                      record.assign_attributes(hash.except(:id, :type))
+                      if !inventory_collection.check_changed? || record.changed?
+                        record.save!
+                        inventory_collection.store_updated_records(record)
+                      end
+
+                      inventory_object.id = record.id
+                    end
+                  end
+                end
+              }
+
+              super(attributes.merge!(extra_attributes))
+            end
+
+            def host_storages(extra_attributes = {})
+              attributes = {
+                :model_class                 => ::HostStorage,
+                :manager_ref                 => [:host, :storage],
+                :association                 => :host_storages,
+                :inventory_object_attributes => [
+                  :ems_ref,
+                  :read_only,
+                  :host,
+                  :storage,
+                ],
+              }
+
+              attributes.merge!(extra_attributes)
+            end
+
+            def host_switches(extra_attributes = {})
+              attributes = {
+                :model_class                 => ::HostSwitch,
+                :manager_ref                 => [:host, :switch],
+                :association                 => :host_switches,
+                :inventory_object_attributes => [
+                  :host,
+                  :switch,
+                ],
+              }
+
+              attributes.merge!(extra_attributes)
+            end
+
+            def switches(extra_attributes = {})
+              attributes = {
+                :model_class                 => ::Switch,
+                :manager_ref                 => [:uid_ems],
+                :association                 => :switches,
+                :inventory_object_attributes => [
+                  :uid_ems,
+                  :name,
+                  :lans
+                ],
+              }
+
+              attributes.merge!(extra_attributes)
+            end
+
+            def lans(extra_attributes = {})
+              attributes = {
+                :model_class                 => ::Lan,
+                :manager_ref                 => [:uid_ems],
+                :association                 => :lans,
+                :inventory_object_attributes => [
+                  :name,
+                  :uid_ems,
+                  :tag
+                ],
+              }
+
+              attributes.merge!(extra_attributes)
+            end
+
+            def snapshot_parent(extra_attributes = {})
+              snapshot_parent_save_block = lambda do |_ems, inventory_collection|
+                snapshot_collection = inventory_collection.dependency_attributes[:snapshots].try(:first)
+
+                snapshot_collection.each do |snapshot|
+                  ActiveRecord::Base.transaction do
+                    child = Snapshot.find(snapshot.id)
+                    parent = Snapshot.find_by(:uid_ems => snapshot.parent_uid)
+                    child.update_attribute(:parent_id, parent.try(:id))
+                  end
+                end
+              end
+
+              attributes = {
+                :association       => :snapshot_patent,
+                :custom_save_block => snapshot_parent_save_block,
+              }
+
+              attributes.merge!(extra_attributes)
+            end
+          end
+        end
+    http_version: 
+  recorded_at: Mon, 19 Feb 2018 14:57:34 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Test results description:

* First file: 
  - Within the base PR `:custom_reconnect_block` was added.
* Second file: 
  - Those two methods were defined in a parent class (but using the current class's values - hence there is no errors on those methods testing)
  - It was a typo before, fixed

Test results:
```spec
azagayno@azagayno:~/work/manageiq$ bundle exec rspec spec/models/manager_refresh/inventory_collection_default_spec.rb:28
** override_gem: manageiq-providers-amazon, [{:path=>"/home/azagayno/work/manageiq/plugins/manageiq-providers-amazon"}], caller: /home/azagayno/work/manageiq/bundler.d/local_plugins.rb
Run options: include {:locations=>{"./spec/models/manager_refresh/inventory_collection_default_spec.rb"=>[28]}}

Randomized with seed 15938
...F..F

Failures:

  1) ManagerRefresh::InventoryCollectionDefault refactoring it should behave like unchanged miq_templates: []
     Failure/Error: expect(new_result).to eq(old_result)
     
       expected: {:model_class=>"MiqTemplate", :association=>:miq_templates, :delete_method=>:disconnect_inv, :attribu...endor], :builder_params=>{:ems_id=>"Proc", :name=>"unknown", :location=>"unknown", :template=>true}}
            got: {:model_class=>"MiqTemplate", :association=>:miq_templates, :use_ar_object=>true, :delete_method=>:di...endor], :builder_params=>{:ems_id=>"Proc", :name=>"unknown", :location=>"unknown", :template=>true}}
     
       (compared using ==)
     
       Diff:
       @@ -2,6 +2,7 @@
        :attributes_blacklist => [:genealogy_parent],
        :batch_extra_attributes => [:power_state, :previous_state, :state_changed_on],
        :builder_params => {:ems_id=>"Proc", :name=>"unknown", :location=>"unknown", :template=>true},
       +:custom_reconnect_block => "Proc",
        :delete_method => :disconnect_inv,
        :inventory_object_attributes => [:boot_time, :connection_state, :ems_cluster, :ems_ref, :ems_ref_obj, :host, :location, :memory_limit, :memory_reserve, :name, :raw_power_state, :snapshots, :storage, :storages, :template, :type, :uid_ems, :vendor],
        :model_class => "MiqTemplate",
       
     Shared Example Group: :unchanged called from ./spec/models/manager_refresh/inventory_collection_default_spec.rb:65
     # ./spec/models/manager_refresh/inventory_collection_default_spec.rb:58:in `block (4 levels) in <top (required)>'

  2) ManagerRefresh::InventoryCollectionDefault refactoring it should behave like unchanged vms: []
     Failure/Error: expect(new_result).to eq(old_result)
     
       expected: {:model_class=>"Vm", :association=>:vms, :delete_method=>:disconnect_inv, :attributes_blacklist=>[:ge...ype, :uid_ems, :vendor], :builder_params=>{:ems_id=>"Proc", :name=>"unknown", :location=>"unknown"}}
            got: {:model_class=>"Vm", :association=>:vms, :use_ar_object=>true, :delete_method=>:disconnect_inv, :save...ype, :uid_ems, :vendor], :builder_params=>{:ems_id=>"Proc", :name=>"unknown", :location=>"unknown"}}
     
       (compared using ==)
     
       Diff:
       @@ -2,6 +2,7 @@
        :attributes_blacklist => [:genealogy_parent],
        :batch_extra_attributes => [:power_state, :previous_state, :state_changed_on],
        :builder_params => {:ems_id=>"Proc", :name=>"unknown", :location=>"unknown"},
       +:custom_reconnect_block => "Proc",
        :delete_method => :disconnect_inv,
        :inventory_object_attributes => [:boot_time, :connection_state, :cpu_limit, :cpu_reserve, :cpu_reserve_expand, :cpu_shares, :cpu_shares_level, :ems_cluster, :ems_ref, :ems_ref_obj, :host, :location, :memory_limit, :memory_reserve, :memory_reserve_expand, :memory_shares, :memory_shares_level, :name, :raw_power_state, :snapshots, :storage, :storages, :template, :type, :uid_ems, :vendor],
        :model_class => "Vm",
       
     Shared Example Group: :unchanged called from ./spec/models/manager_refresh/inventory_collection_default_spec.rb:65
     # ./spec/models/manager_refresh/inventory_collection_default_spec.rb:58:in `block (4 levels) in <top (required)>'

Finished in 0.03829 seconds (files took 7.6 seconds to load)
7 examples, 2 failures

Failed examples:

rspec ./spec/models/manager_refresh/inventory_collection_default_spec.rb[1:2:4:1] # ManagerRefresh::InventoryCollectionDefault refactoring it should behave like unchanged miq_templates: []
rspec ./spec/models/manager_refresh/inventory_collection_default_spec.rb[1:2:2:1] # ManagerRefresh::InventoryCollectionDefault refactoring it should behave like unchanged vms: []

Randomized with seed 15938
```
```spec
azagayno@azagayno:~/work/manageiq$ bundle exec rspec spec/models/manager_refresh/inventory_collection_default/infra_manager_spec.rb 
** override_gem: manageiq-providers-amazon, [{:path=>"/home/azagayno/work/manageiq/plugins/manageiq-providers-amazon"}], caller: /home/azagayno/work/manageiq/bundler.d/local_plugins.rb

Randomized with seed 49208
F..................F.

Failures:

  1) ManagerRefresh::InventoryCollectionDefault::InfraManager refactoring should eq [:hosts, :snapshots, :vms, :storages, :custom_attributes, :guest_devices, :resource_pools, :switches,..._switches, :datacenters, :host_networks, :host_hardwares, :host_operating_systems, :snapshot_parent]
     Failure/Error: it { expect(@new_methods).to eq(@old_methods) }
     
       expected: [:hosts, :snapshots, :vms, :storages, :custom_attributes, :guest_devices, :resource_pools, :switches,..._switches, :datacenters, :host_networks, :host_hardwares, :host_operating_systems, :snapshot_parent]
            got: [:hosts, :snapshots, :storages, :custom_attributes, :guest_devices, :resource_pools, :switches, :netw..._switches, :datacenters, :host_networks, :host_hardwares, :host_operating_systems, :snapshot_parent]
     
       (compared using ==)
     
       Diff:
       
       @@ -1,13 +1,11 @@
        [:hosts,
         :snapshots,
       - :vms,
         :storages,
         :custom_attributes,
         :guest_devices,
         :resource_pools,
         :switches,
         :networks,
       - :operating_systems,
         :ems_folders,
         :ems_clusters,
         :host_storages,
       
     # ./spec/models/manager_refresh/inventory_collection_default/infra_manager_spec.rb:39:in `block (3 levels) in <top (required)>'

  2) ManagerRefresh::InventoryCollectionDefault::InfraManager refactoring it should behave like unchanged snapshot_parent: []
     Failure/Error: expect(new_result).to eq(old_result)
     
       expected: {:association=>:snapshot_patent, :custom_save_block=>"Proc"}
            got: {:association=>:snapshot_parent, :custom_save_block=>"Proc"}
     
       (compared using ==)
     
       Diff:
       @@ -1,3 +1,3 @@
       -:association => :snapshot_patent,
       +:association => :snapshot_parent,
        :custom_save_block => "Proc",
       
     Shared Example Group: :unchanged called from ./spec/models/manager_refresh/inventory_collection_default/infra_manager_spec.rb:42
     # ./spec/models/manager_refresh/inventory_collection_default/infra_manager_spec.rb:35:in `block (4 levels) in <top (required)>'

Finished in 0.06775 seconds (files took 7.76 seconds to load)
21 examples, 2 failures

Failed examples:

rspec ./spec/models/manager_refresh/inventory_collection_default/infra_manager_spec.rb:39 # ManagerRefresh::InventoryCollectionDefault::InfraManager refactoring should eq [:hosts, :snapshots, :vms, :storages, :custom_attributes, :guest_devices, :resource_pools, :switches,..._switches, :datacenters, :host_networks, :host_hardwares, :host_operating_systems, :snapshot_parent]
rspec ./spec/models/manager_refresh/inventory_collection_default/infra_manager_spec.rb[1:1:19:1] # ManagerRefresh::InventoryCollectionDefault::InfraManager refactoring it should behave like unchanged snapshot_parent: []

Randomized with seed 49208
```